### PR TITLE
Lateral command tooltips are now above panel

### DIFF
--- a/client/resources/stylesheets/ui/lateralbar.less
+++ b/client/resources/stylesheets/ui/lateralbar.less
@@ -17,8 +17,7 @@
             top: 0px;
             bottom: 9px;
             height: 100%;
-            z-index: 1;
-            overflow: hidden;
+            z-index: 2;
             background: @codeboxBodyBackground;
         }
 


### PR DESCRIPTION
Tooltips for buttons in lateral menu were below panel, so user would just see less than half of them. Now they're fully visible.
