### PR TITLE
Fix login input usage on touchscreens (#95)

### DIFF
--- a/client/resources/stylesheets/ui/login.less
+++ b/client/resources/stylesheets/ui/login.less
@@ -40,7 +40,10 @@
         }
 
         .inner {
-            
+            input {
+                -webkit-user-select: text;
+                user-select: text;
+            }
         }
     }
 }


### PR DESCRIPTION
user-select: none; (applied from *)  meant that you couldn't enter text into the inputs when using a tablet.

I'm unsure where else inputs are used throughout this project. Right now, any others are still unusable. May want to consider changing the \* rule in main.less to *:not(input) or something similar.
