### PR TITLE
fix npm start script to load .env in sh (instead of just bash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         }
     ],
     "scripts": {
-        "start": "[ -f .env ] && source .env || echo 'Store your environment config in .env'; ./node_modules/.bin/grunt"
+        "start": "[ -f .env ] && . ./.env || echo 'Store your environment config in .env'; ./node_modules/.bin/grunt"
     },
     "main": "index.js"
 }


### PR DESCRIPTION
for #285
