### PR TITLE
Fixed 'utils' typo

### DIFF
--- a/core/codebox.js
+++ b/core/codebox.js
@@ -2,7 +2,7 @@
 var Q = require('q');
 var _ = require('lodash');
 
-var urils = require('./utils');
+var utils = require('./utils');
 var os = require('os');
 var path = require('path');
 var Gittle = require('gittle');


### PR DESCRIPTION
Fixed typo. However 'utils' is not being used and could be omitted
