### PR TITLE
Increased AddOn loading time-out to 60 secs

### DIFF
--- a/client/models/addon.js
+++ b/client/models/addon.js
@@ -83,7 +83,7 @@ define([
                 }
             }, register);
 
-            return d.promise.timeout(5000, "This addon took to long to load (> 5seconds)");
+            return d.promise.timeout(60000, "This addon took to long to load (> 60 seconds)");
         },
 
         /**


### PR DESCRIPTION
When loading the CodeBox IDE over a low network, it may actually takes
longer than 5 secs to load the add-ons. As this parameter is NOT configurable
at the moment, it is then safer to extend it to at least 1 minute.
