### PR TITLE
Use workspace Git repository identity instead of CodeBox one

### DIFF
--- a/bin/codebox.js
+++ b/bin/codebox.js
@@ -68,7 +68,6 @@ cli.command('run [folder]')
         return x.split(':', 2);
     }));
 
-
     var config = {
         'root': that.directory,
         'title': that.title,

--- a/core/codebox.js
+++ b/core/codebox.js
@@ -13,7 +13,6 @@ var LOCAL_SETTINGS_DIR = path.join(
 );
 
 var start = function(config) {
-    var codeboxGitRepo = new Gittle(path.resolve(__dirname, ".."));
     var prepare = Q();
 
     // Options
@@ -83,6 +82,8 @@ var start = function(config) {
 
     // Normalize root path
     config.root = path.resolve(process.cwd(), config.root);
+
+    var codeboxGitRepo = new Gittle(config.root);
 
     // Default title
     if (config.title == null) {


### PR DESCRIPTION
When instantiating a CodeBox instance on a workspace, the Git
identity should be set to the workspace repository Git user/email
and not to the Git user that cloned CodeBox.