### PR TITLE
Use the official substack/shux distribution instead of Samy's fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "express": "3.3.5",
         "socket.io": "0.9.16",
         "loadfire": "1.3.4",
-        "shux": "git+https://github.com/SamyPesse/shux.git#3abe4c6074013791eac0d055c63ed70b3197e7f4",
+        "shux": "1.0.0",
         "vfs-http-adapter": "git+https://github.com/AaronO/vfs-http-adapter.git#6c9934e4f2da7886310397170b6ebaf745833936",
         "vfs-local": "git+https://github.com/FriendCode/vfs-local.git#af6bafede0ccb9fb362a0c280e708648f7363f33",
         "watchr": "2.4.11",


### PR DESCRIPTION
CodeBox 0.8.1 was using Samy's private repo with an OAuth token
as Shux distribution. The OAuth token has been revocked and as
a result CodeBox 0.8.1 cannot be installed (or built) anymore.

We need this change on top of 0.8.1 to make it work again :-)