### PR TITLE
Include PR #468 and PR #469

### DIFF
--- a/bin/codebox.js
+++ b/bin/codebox.js
@@ -68,7 +68,6 @@ cli.command('run [folder]')
         return x.split(':', 2);
     }));
 
-
     var config = {
         'root': that.directory,
         'title': that.title,

--- a/client/models/addon.js
+++ b/client/models/addon.js
@@ -83,7 +83,7 @@ define([
                 }
             }, register);
 
-            return d.promise.timeout(5000, "This addon took to long to load (> 5seconds)");
+            return d.promise.timeout(60000, "This addon took to long to load (> 60 seconds)");
         },
 
         /**

--- a/core/codebox.js
+++ b/core/codebox.js
@@ -13,7 +13,6 @@ var LOCAL_SETTINGS_DIR = path.join(
 );
 
 var start = function(config) {
-    var codeboxGitRepo = new Gittle(path.resolve(__dirname, ".."));
     var prepare = Q();
 
     // Options
@@ -83,6 +82,8 @@ var start = function(config) {
 
     // Normalize root path
     config.root = path.resolve(process.cwd(), config.root);
+
+    var codeboxGitRepo = new Gittle(config.root);
 
     // Default title
     if (config.title == null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codebox",
-    "version": "0.8.1",
+    "version": "0.8.2",
     "description": "Open source cloud & desktop IDE.",
     "homepage": "https://www.codebox.io",
     "author": "FriendCode Inc. <contact@friendco.de>",
@@ -20,7 +20,7 @@
         "express": "3.3.5",
         "socket.io": "0.9.16",
         "loadfire": "1.3.4",
-        "shux": "git+https://github.com/SamyPesse/shux.git#3abe4c6074013791eac0d055c63ed70b3197e7f4",
+        "shux": "1.0.0",
         "vfs-http-adapter": "git+https://github.com/AaronO/vfs-http-adapter.git#6c9934e4f2da7886310397170b6ebaf745833936",
         "vfs-local": "git+https://github.com/FriendCode/vfs-local.git#af6bafede0ccb9fb362a0c280e708648f7363f33",
         "watchr": "2.4.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "codebox",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "description": "Open source cloud & desktop IDE.",
     "homepage": "https://www.codebox.io",
     "author": "FriendCode Inc. <contact@friendco.de>",


### PR DESCRIPTION
When loading the CodeBox IDE over a low network, it may actually takes
longer than 5 secs to load the add-ons. As this parameter is NOT configurable
at the moment, it is then safer to extend it to at least 1 minute.

Additionally, when instantiating a CodeBox instance on a workspace, the Git
identity should be set to the workspace repository Git user/email
and not to the Git user that cloned CodeBox.
